### PR TITLE
feat: attempt to have array size as a parameter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,18 +6,23 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0")
 
 include(FindOpenMP)
 
-function(doa_all_bench_gen array_size)
-    add_executable(doall_bench_${array_size} doall_bench.cc commons.cc)
-    target_compile_definitions(doall_bench_${array_size} PRIVATE ARRAY_SIZE=${array_size})
-    if(OpenMP_CXX_FOUND)
-        target_link_libraries(doall_bench_${array_size} PUBLIC OpenMP::OpenMP_CXX)
-    endif()
-endfunction(doa_all_bench_gen)
+#function(doa_all_bench_gen array_size)
+#    add_executable(doall_bench_${array_size} doall_bench.cc commons.cc)
+#    target_compile_definitions(doall_bench_${array_size} PRIVATE ARRAY_SIZE=${array_size})
+#    if(OpenMP_CXX_FOUND)
+#        target_link_libraries(doall_bench_${array_size} PUBLIC OpenMP::OpenMP_CXX)
+#    endif()
+#endfunction(doa_all_bench_gen)
 
 #foreach (array_size 1 4 16 64 256 1024 4096 16384 65536 262144)
-foreach (array_size 1 1024)
-    doa_all_bench_gen(${array_size})
-endforeach ()
+#foreach (array_size 1 1024)
+#    doa_all_bench_gen(${array_size})
+#endforeach ()
+
+
+add_executable(doall_bench
+        doall_bench.cc
+        commons.cc)
 
 add_executable(reduction_bench
         reduction_bench.cc
@@ -44,6 +49,7 @@ add_executable(reduction_bench
 #        commons.cc)
 
 if(OPENMP_FOUND)
+    target_link_libraries(doall_bench PUBLIC OpenMP::OpenMP_CXX)
     target_link_libraries(reduction_bench PUBLIC OpenMP::OpenMP_CXX)
 #    target_link_libraries(task_bench PUBLIC OpenMP::OpenMP_CXX)
 #    target_link_libraries(schedule_bench PUBLIC OpenMP::OpenMP_CXX)

--- a/commons.h
+++ b/commons.h
@@ -26,6 +26,9 @@ public:
     unsigned int gpu_threads;
 };
 
+/// @brief The sizes of the arrays used in data sharing and reduction clauses
+extern std::vector<unsigned long long> ARRAY_SIZES;
+
 /// @brief The number of times each test should get repeated, for median taking
 extern std::vector<unsigned int> TEST_REPETITIONS;
 
@@ -92,7 +95,7 @@ void ParseArgsTaskTree(int argc , char **argv);
 /// @param test the reference to the function to get benchmarked
 /// @param ref the reference to the reference function, typically a serial implementation of the same code
 void Benchmark(const std::string &bench_name, const std::string &test_name, void (&test)(const DataPoint&),
-               void (&ref)(const DataPoint&));
+               void (&ref)(const DataPoint&), void (&preprocessing)(const DataPoint&), void (&postprocessing)());
 
 /// @brief These benchmark methods are getting called by the microbenchmarks itself
 /// @param bench_name the name of the microbenchmark

--- a/reduction_bench.cc
+++ b/reduction_bench.cc
@@ -9,6 +9,20 @@ std::string bench_name = "REDUCTION";
 unsigned long long num_tasks = 1;
 unsigned long long grainsize = 1;
 
+/// @brief Sets up a microbenchmark
+/// Sets the vector, because we don't want to benchmark on this.
+/// Has to get called before every microbenchmark
+void Preprocessing(const DataPoint& data) {
+    // TODO move assignments here
+}
+
+/// @brief Finishes the microbenchmark
+/// Deleting the vector, so no memory leaks exist
+/// Has to get called after every microbenchmark
+void Postprocessing() {
+    
+}
+
 int main(int argc, char **argv) {
 
     ParseArgs(argc, argv);
@@ -31,15 +45,15 @@ void RunBenchmarks() {
         num_tasks = i;
         grainsize = i;
         Benchmark(bench_name, "TASKLOOP_NUM_TASKS_" + std::to_string(num_tasks), ReductionTaskloopNumTasks,
-                  Reference);
+                  Reference, Preprocessing, Postprocessing);
         Benchmark(bench_name, "TASKLOOP_GRAINSIZE_" + std::to_string(grainsize), ReductionTaskloopGrainsize,
-                  Reference);
+                  Reference, Preprocessing, Postprocessing);
     }
 
-    Benchmark(bench_name, "FOR", ReductionFor, Reference);
-    Benchmark(bench_name, "TASKLOOP", ReductionTaskloop, Reference);
-    Benchmark(bench_name, "TASK", ReductionTask, Reference);
-    Benchmark(bench_name, "TASKGROUP", ReductionTaskgroup, Reference);
+    Benchmark(bench_name, "FOR", ReductionFor, Reference, Preprocessing, Postprocessing);
+    Benchmark(bench_name, "TASKLOOP", ReductionTaskloop, Reference, Preprocessing, Postprocessing);
+    Benchmark(bench_name, "TASK", ReductionTask, Reference, Preprocessing, Postprocessing);
+    Benchmark(bench_name, "TASKGROUP", ReductionTaskgroup, Reference, Preprocessing, Postprocessing);
 
 }
 


### PR DESCRIPTION
@lukasrothenberger I can't manage to tell openmp to use a dynamically allocated array in data sharing clauses.

`private(arr)` on a statically allocated array creates for each thread an array of the same size. But on a dynamically allocated array it only does this with the pointer (and since it is uninitialized it points to arbitrary memory locations, causing segmentation faults unless we change the benchmarks). 

Is it possible to have a dynamically created array (however we create it: `new float[x]()`, `malloc`, ....) and tell openmp to create (first)private copies of the same size? After trying for far too long I could still not find out a way to do it and I am starting to feel like it is not possible at all.

If we wanted to implement the same functionality we could obviously create an array of arrays. Then each thread can use one of the inner arrays. But how would we measure the overhead associated with this? It is all "manually" doable but I do not see a point of doing it in a Benchmark...

We could also statically create arrays of different sizes with the downside that we would have to know the sizes at compile time.
